### PR TITLE
Remove trove games from default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Integration for GOG Galaxy 2.0.
 
 ## Features
 
-* Library: DRM free games from HumbleBundle (those with downloads for Windows, MacOS or Linux)
-* Library: Humble Trove games
-* Library: Third pary game keys
+* Library:
+    * DRM free direct downloads from HumbleBundle
+    * Third pary game keys
+    * Humble Trove games
 * Install: simple download via webbrowser
-* Launch: autodetection of installed games:
-    * scanning Windows registry if game suppports this (if can be uninstalled from `Control Panel\Programs\Programs and Features`)
-    * scanning file directory trees given in config file (experimental feature) 
+* Installed games detection:
+    * scanning Windows registry (only for games that can be uninstalled via `Control Panel\Programs\Programs and Features`)
+    * scanning file directory trees given in config file (experimental - 1level deep tree search for directories names similar to game names from library)
 * Launch: running games tracking (only if launched via Galaxy)
 
 ## Installation
 
-Unpack `humblebundle_v{}.zip` asset from latest [release][1] to:
+Download asset `humblebundle_v{}.zip` from [releases][1] and upack to:
 - Windows: `%localappdata%\GOG.com\Galaxy\plugins\installed`
 - MacOS: `~/Library/Application Support/GOG.com/Galaxy/plugins/installed`
 
@@ -28,13 +29,13 @@ or build from source code (requires `python3.6` or higher):
 
 ## Configuration
 
-Refer to [config.ini](src/config.ini)
+Edit your local [config.ini](src/config.ini)
 
-## Known Issues
+#### Defaults:
+- Library: List DRM-free games and unrevealed third party keys
+- Installed games: use only Windows registry scan; edit `search_paths` to enable directory scaning feature
 
-- no launch support for macOS
-
-## See also
+## Acknowledgements
 - https://github.com/gogcom/galaxy-integrations-python-api
 - https://github.com/MayeulC/hb-downloader
 

--- a/src/config.ini
+++ b/src/config.ini
@@ -1,20 +1,19 @@
 # Config file for HumbleBundle integration
-# Changes are loaded on the file save, even if plugin is running in GOG Galaxy
-# Configuration is sync with Galaxy local database storage so in case of plugin removal or update your last settings should be propertly recreated.
+# Changes are loaded on the file save. Config is sync with Galaxy local storage.
 
-# `sources` coma-separated list of game types that will be shown in your GOG Galaxy library. Duplicates will be resolved according to the specified list order.
+# `[library]-sources` coma-separated list of game types that will be shown in your GOG Galaxy library. Duplicates will be resolved according to the specified list order.
 # Available options:
     # drm-free: only games that have direct download for windows/macos/linux visible in https://www.humblebundle.com/home/library
     # trove: Monthly subscription games. Will be shown only if you were subscriber at least once.
     # keys: games defined as keys to be redeem in foreign services (Steam/Origin/Uplay/Epic/Battle.net).
 # Modify the list to manage your humblebundle collection in GOG Galaxy library or change priority order (games from higher positioned type gets priority).
 
-# `show_revealed_keys` defines if already revealed "key" games should be shown. Ignored when no `keys` in `sources` list.
+# `[library]-show_revealed_keys` defines if already revealed "key" games should be shown. Ignored when no `keys` in `sources` list.
 # Set to true if you want to show all keys.
 # Default is false, because if a game key is reedemed on your steam/origin/uplay/battle.net account, it should be aslo visible in the relevant Galaxy integration.
 # Note: revealed key doesn't mean that it is activated (reedemed) in APPROPRIATE steam/origin account
 
-# `installed`-`search_dirs`: list of directory paths for installed games lookup. Environmental variables are supported.
+# `[installed]-search_dirs`: list of directory paths for installed games lookup. Environmental variables are supported.
 # For example:
 # search_dirs = [
     # 'D:/Games/HumbleBundle',
@@ -22,8 +21,9 @@
     # '%programfiles(x86)%', # Program Files(x86)
 # ]
 # ===
+
 [library]
-sources = [ "drm-free", "trove", "keys",]
+sources = [ "drm-free", "keys",]
 show_revealed_keys = false
 
 [installed]

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -202,7 +202,7 @@ class HumbleBundlePlugin(Plugin):
         owned_title_id = {v.human_name: k for k, v in self._owned_games.items() if not isinstance(v, Key)}
         if self._rescan_needed and self._settings is not None:
             self._rescan_needed = False
-            logging.debug(f'Checking installed games with path scanning')
+            logging.debug(f'Checking installed games with path scanning in: {self._settings.installed.search_dirs}')
             self._local_games = await self._app_finder.find_local_games(owned_title_id, self._settings.installed.search_dirs)
         else:
             self._local_games.update(await self._app_finder.find_local_games(owned_title_id, None))


### PR DESCRIPTION
Looks like more people exclude trove games, that is why default change
It is still configurable in config.ini