### PR TITLE
Fix for recognizing re-installed games

### DIFF
--- a/src/local/reg_watcher.py
+++ b/src/local/reg_watcher.py
@@ -96,14 +96,10 @@ class WinRegUninstallWatcher:
                     subkeys = winreg.QueryInfoKey(key)[0]
 
                     cached_subkeys = self.__keys_count[hive | arch_key]
-                    if subkeys == cached_subkeys:
-                        continue  # equal number of installed programs since last refresh
                     self.__keys_count[hive | arch_key] = subkeys
-
-                    if subkeys < cached_subkeys:
-                        logging.debug(f'Uninstallation detected. No need to scan {hive | arch_key} registry.') 
-                        continue
-                    logging.debug(f'New keys in registry {hive | arch_key}: {subkeys}. Reparsing.')
+                    if subkeys <= cached_subkeys:
+                        continue  # same or lower number of installed programs since last refresh
+                    logging.info(f'New keys in registry {hive | arch_key}: {subkeys}. Reparsing.')
 
                     for i in range(subkeys):
                         subkey_name = winreg.EnumKey(key, i)


### PR DESCRIPTION
Fixes #34 
cache installed programs number + gets rid of premature optimization for subkey names.

That means for every new installation plugin will recheck all uninstall keys (~2sec of a bit higher CPU usage), what is acceptable as the installation process has high CPU drain itself.

Previously the plugin was using cache to omit already scanned keys, but A) it wasn't so efficient, as getting subkey name also takes some resources; B) it fails on game re-installation. It is not so uncommon case as people may want to reinstall game when encounter any problem with it (or just to use another hard drive)