### PR TITLE
Fix for handling titles longer than 100chars

### DIFF
--- a/src/model/game.py
+++ b/src/model/game.py
@@ -44,7 +44,8 @@ class HumbleGame(abc.ABC):
 
     def in_galaxy_format(self):
         dlcs = []  # not supported for now
-        return Game(self.machine_name, self.human_name, dlcs, self.license)
+        truncated_name = self.human_name[:100]
+        return Game(self.machine_name, truncated_name, dlcs, self.license)
 
     def __repr__(self):
         return str(self)

--- a/tasks.py
+++ b/tasks.py
@@ -159,8 +159,9 @@ def archive(c, zip_name=None, target=None):
 def create_tag(c, tag=None):
     if tag is None:
         tag = 'v' + __version__
+    branch = c.run("git rev-parse --abbrev-ref HEAD").stdout.strip()
 
-    print(f'New tag version for release will be: {tag}. is it OK?')
+    print(f'New tag version for release will be: [{tag}] on [{branch}] branch. is it OK?')
     if input('y/n').lower() != 'y':
         return
 


### PR DESCRIPTION
Galaxy backend do not accept titles longer than 100chars. The problem was reported, as Galaxy Client cannot handle such exceptions (see #65)

But for now - simply workaround it by truncating long titles to max 100 characters.