### PR TITLE
Split keys when contain multiple games

### DIFF
--- a/src/library.py
+++ b/src/library.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Set, Iterable, Any, Coroutine
 
 from consts import SOURCE, NON_GAME_BUNDLE_TYPES, GAME_PLATFORMS
 from model.product import Product
-from model.game import HumbleGame, Subproduct, TroveGame, Key
+from model.game import HumbleGame, Subproduct, TroveGame, Key, KeyGame
 from settings import LibrarySettings
 
 
@@ -166,7 +166,7 @@ class LibraryResolver:
         return trove_games
 
     @staticmethod
-    def _get_keys(orders: list, show_revealed_keys: bool) -> List[Key]:
+    def _get_keys(orders: list, show_revealed_keys: bool) -> List[KeyGame]:
         keys = []
         for details in orders:
             for tpks in details['tpkd_dict']['all_tpks']:
@@ -176,5 +176,5 @@ class LibraryResolver:
                     logging.error(f"Error while parsing tpks {repr(e)}: {tpks}", extra={'tpks': tpks})
                 else:
                     if key.key_val is None or show_revealed_keys:
-                        keys.append(key)
+                        keys.extend(key.key_games)
         return keys

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -156,7 +156,8 @@ class KeyGame(Key):
     
     @property
     def human_name(self):
-        """Adds key identity if not already present"""
+        """Uses heuristics to add key identity if not already present.
+        The heuristics may be wrong but it is not very harmfull."""
         key_type = super().key_type_human_name 
         keywords = [" Key", key_type]
         for keyword in keywords:

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -124,7 +124,8 @@ class Key(HumbleGame):
 
     @property
     def key_type_human_name(self) -> str:
-        return self._data['key_type_human_name']
+        extra_safety_default = 'Key'
+        return self._data.get('key_type_human_name', extra_safety_default)
 
     @property
     def key_val(self) -> Optional[str]:
@@ -155,7 +156,13 @@ class KeyGame(Key):
     
     @property
     def human_name(self):
-        return self._game_name
+        """Adds key identity if not already present"""
+        key_type = super().key_type_human_name 
+        keywords = [" Key", key_type]
+        for keyword in keywords:
+            if keyword in self._game_name or key_type in self._game_name:
+                return self._game_name
+        return f'{self._game_name} ({key_type})'
 
     @property
     def machine_name(self):

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -134,7 +134,7 @@ class Key(HumbleGame):
     @property
     def key_games(self) -> List['KeyGame']:
         """One key can represent multiple games listed in human_name.
-        This property split those games and returns list of KeyGame objects with incremental id.
+        This property splits those games and returns list of KeyGame objects with incremental id.
         """
         names = self.human_name.split(', ')
         if len(names) == 1:

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -133,17 +133,30 @@ class Key(HumbleGame):
     
     @property
     def key_games(self) -> List['KeyGame']:
+        """One key can represent multiple games listed in human_name.
+        This property split those games and returns list of KeyGame objects with incremental id.
+        """
         names = self.human_name.split(', ')
-        return [KeyGame(self, name) for name in names]
+        if len(names) == 1:
+            return [KeyGame(self, self.machine_name, self.human_name)]
+        else:
+            return [
+                KeyGame(self, f'{self.machine_name}_{i}', name)
+                for i, name in enumerate(names)
+            ]
 
 
 class KeyGame(Key):
     """One key can represent multiple games listed in key.human_name"""
-    def __init__(self, key: Key, game_human_name: str):
-        self._game_human_name = game_human_name
+    def __init__(self, key: Key, game_id: str, game_name: str):
+        self._game_name = game_name
+        self._game_id = game_id
         super().__init__(key._data)
     
     @property
     def human_name(self):
-        return self._game_human_name
+        return self._game_name
 
+    @property
+    def machine_name(self):
+        return self._game_id

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -130,3 +130,20 @@ class Key(HumbleGame):
     def key_val(self) -> Optional[str]:
         """If returned value is None - the key was not revealed yet"""
         return self._data.get('redeemed_key_val')
+    
+    @property
+    def key_games(self) -> List['KeyGame']:
+        names = self.human_name.split(', ')
+        return [KeyGame(self, name) for name in names]
+
+
+class KeyGame(Key):
+    """One key can represent multiple games listed in key.human_name"""
+    def __init__(self, key: Key, game_human_name: str):
+        self._game_human_name = game_human_name
+        super().__init__(key._data)
+    
+    @property
+    def human_name(self):
+        return self._game_human_name
+

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -160,7 +160,7 @@ class KeyGame(Key):
         key_type = super().key_type_human_name 
         keywords = [" Key", key_type]
         for keyword in keywords:
-            if keyword in self._game_name or key_type in self._game_name:
+            if keyword in self._game_name:
                 return self._game_name
         return f'{self._game_name} ({key_type})'
 

--- a/tests/common/model/test_game.py
+++ b/tests/common/model/test_game.py
@@ -46,9 +46,10 @@ def test_key_key_games_one_game():
     """Most common case where 1 key == 1 game"""
     key = Key({
         "machine_name": "ww",
-        "human_name": "The Witcher"
+        "human_name": "The Witcher",
+        "key_type_human_name": "Steam Key"
     })
-    assert key.key_games == [KeyGame(key, "ww", "The Witcher")]
+    assert key.key_games == [KeyGame(key, "ww", "The Witcher (Steam Key)")]
 
 
 def test_key_key_game_data():
@@ -72,3 +73,22 @@ def test_key_split_key_games():
         KeyGame(key, "sega_2", "Rome: Total War"),
         KeyGame(key, "sega_3", "Hell Yeah! Wrath of the Dead Rabbit")
     ]
+
+
+def test_key_game_human_name_changed():
+    tpks = {
+        'machine_name': 'tor',
+        'human_name': 'Tor',
+        'key_type_human_name': 'Steam Key'
+    }
+    assert KeyGame(Key(tpks), 'tor', 'Tor').human_name == 'Tor (Steam Key)'
+
+
+def test_key_game_human_name_not_changed():
+    tpks = {
+        'machine_name': 'tor',
+        'human_name': 'Tor Steam',
+        'key_type_human_name': 'Steam'
+    }
+    assert KeyGame(Key(tpks), 'tor', 'Tor Steam').human_name == 'Tor Steam'
+

--- a/tests/common/model/test_game.py
+++ b/tests/common/model/test_game.py
@@ -1,4 +1,4 @@
-from model.game import Subproduct, Key
+from model.game import Subproduct, Key, KeyGame
 from consts import GAME_PLATFORMS, HP
 
 
@@ -40,3 +40,33 @@ def test_key_properties(origin_bundle_order):
         key.key_val
         key.downloads
         key.in_galaxy_format()
+
+
+def test_key_key_games_simple():
+    key = Key({
+        "machine_name": "ww",
+        "human_name": "The Witcher"
+    })
+    assert key.key_games == [KeyGame(key, "The Witcher")]
+
+
+def test_key_key_games_key_data():
+    key = Key({
+        "machine_name": "ww",
+        "human_name": "The Witcher, The Witcher 2"
+    })
+    assert key._data == KeyGame(key, 'sth')._data
+
+
+def test_key_split_key_games():
+    tpks = {
+        "machine_name": "sega",
+        "human_name": "Alpha Protocol, Company of Heroes, Rome: Total War, Hell Yeah! Wrath of the Dead Rabbit",
+    }
+    key = Key(tpks)
+    assert key.key_games == [
+        KeyGame(key, "Alpha Protocol"),
+        KeyGame(key, "Company of Heroes"),
+        KeyGame(key, "Rome: Total War"),
+        KeyGame(key, "Hell Yeah! Wrath of the Dead Rabbit")
+    ]

--- a/tests/common/model/test_game.py
+++ b/tests/common/model/test_game.py
@@ -42,20 +42,22 @@ def test_key_properties(origin_bundle_order):
         key.in_galaxy_format()
 
 
-def test_key_key_games_simple():
+def test_key_key_games_one_game():
+    """Most common case where 1 key == 1 game"""
     key = Key({
         "machine_name": "ww",
         "human_name": "The Witcher"
     })
-    assert key.key_games == [KeyGame(key, "The Witcher")]
+    assert key.key_games == [KeyGame(key, "ww", "The Witcher")]
 
 
-def test_key_key_games_key_data():
-    key = Key({
+def test_key_key_game_data():
+    tpks = {
         "machine_name": "ww",
         "human_name": "The Witcher, The Witcher 2"
-    })
-    assert key._data == KeyGame(key, 'sth')._data
+    }
+    key = Key(tpks)
+    assert tpks == KeyGame(key, 'ww', 'sth')._data
 
 
 def test_key_split_key_games():
@@ -65,8 +67,8 @@ def test_key_split_key_games():
     }
     key = Key(tpks)
     assert key.key_games == [
-        KeyGame(key, "Alpha Protocol"),
-        KeyGame(key, "Company of Heroes"),
-        KeyGame(key, "Rome: Total War"),
-        KeyGame(key, "Hell Yeah! Wrath of the Dead Rabbit")
+        KeyGame(key, "sega_0", "Alpha Protocol"),
+        KeyGame(key, "sega_1", "Company of Heroes"),
+        KeyGame(key, "sega_2", "Rome: Total War"),
+        KeyGame(key, "sega_3", "Hell Yeah! Wrath of the Dead Rabbit")
     ]

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -58,7 +58,7 @@ async def test_library_fetch(plugin_mock, get_torchlight, get_torchlight_trove, 
     result = await plugin_mock._library_resolver()
     assert result[drm_free.machine_name] == drm_free
     # deduplication of the same title game
-    assert key.machine_name not in result
+    # keys won't be deduplicated as they are forced to have additional info in name like "Steam Key"
     assert trove.machine_name not in result
 
     # cache and calls to api

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -96,7 +96,7 @@ async def test_library_cache_orders(plugin_mock, get_torchlight, change_settings
 
     change_settings(plugin_mock, {'sources': ['keys']})
     result = await plugin_mock._library_resolver(only_cache=True)
-    assert result[key.machine_name] == key
+    assert result[key.machine_name] == key.key_games[0]
     assert drm_free.machine_name not in result
     # no api calls if cache used
     assert plugin_mock._api.get_gamekeys.call_count == 0

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, mock_open, MagicMock, patch
+from unittest.mock import Mock, mock_open, patch
 from pathlib import Path
 from dataclasses import dataclass
 import pytest


### PR DESCRIPTION
Some activate keys (at least for Steam) contains multiple products to be redeem at once. The idea for this integration is to extract those products and show them as separate games. 

Technically it is possible only by splitting key `human_name` by comas and multiplying the rest of such key with slightly different id. 

Sounds risky as it may produce false positives for key games containing regular comas in their names. I've not found any so far (but my library is not the biggest though. But they can be probably fixed case by case by someone behind GOG gamesdb. And lacking games that were just not send so far (or were spammed in gog db because are not single "game"), cannot be solved in this way. So there is more advantages in "unhiding" many of the humble games than loosing few possibly recoverable. I hope.

Closes #65

Additionally I've added to all key games some kind of key indicator - all new key names imported to Galaxy should contain `(Steam)`, `(Steam Key)` or `(Key)`, etc. (depending on what humble API returns).
Unfortunately all already imported games won't be affected this change. 
See #84 for rationale.