### PR TITLE
Import tags feature

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -15,7 +15,7 @@ import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
 from galaxy.api.plugin import Plugin, create_and_run_plugin
 from galaxy.api.consts import Platform, OSCompatibility
-from galaxy.api.types import Authentication, NextStep, LocalGame
+from galaxy.api.types import Authentication, NextStep, LocalGame, GameLibrarySettings
 from galaxy.api.errors import AuthenticationRequired, InvalidCredentials
 
 from consts import HP, CURRENT_SYSTEM
@@ -164,6 +164,17 @@ class HumbleBundlePlugin(Plugin):
             logging.exception(e, extra={'game': game})
         finally:
             self._under_instalation.remove(game_id)
+    
+    async def get_game_library_settings(self, game_id: str, context: Any) -> GameLibrarySettings:
+        gls = GameLibrarySettings(game_id, None, None)
+        game = self._owned_games[game_id]
+        if isinstance(game, Key):
+            gls.tags = ['Key']
+            if game.key_val is None:
+                gls.tags.append('Unrevealed')
+        if isinstance(game, TroveGame):
+            gls.tags = ['Trove']
+        return gls
 
     async def launch_game(self, game_id):
         try:

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -7,6 +7,26 @@ from unittest.mock import Mock
 from galaxy.api.errors import UnknownError
 
 from library import LibraryResolver
+from model.game import Key, Subproduct, TroveGame
+
+
+@pytest.fixture
+def get_torchlight_trove(get_troves):
+    troves_data = get_troves(from_index=0)
+    for i in troves_data:
+        if i['machine_name'] == 'torchlight_trove':
+            trove_torchlight = i
+    return trove_torchlight, TroveGame(trove_torchlight)
+
+
+@pytest.fixture
+def get_torchlight(orders_keys):
+    for i in orders_keys:
+        if i['product']['machine_name'] == 'torchlight_storefront':
+            torchlight_order = i
+    drm_free = Subproduct(torchlight_order['subproducts'][0])
+    key = Key(torchlight_order['tpkd_dict']['all_tpks'][0])
+    return torchlight_order, drm_free, key
 
 
 @pytest.fixture
@@ -30,7 +50,7 @@ def change_settings():
 
 @pytest.mark.asyncio
 async def test_library_fetch(plugin_mock, get_torchlight, get_torchlight_trove, change_settings, orders_keys):
-    torchlight_data, drm_free, key = get_torchlight
+    torchlight_data, drm_free, _ = get_torchlight
     _, trove = get_torchlight_trove
 
     plugin_mock.push_cache.reset_mock()  # reset initial settings push

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock
 from galaxy.api.errors import UnknownError
 
 from library import LibraryResolver
-from model.game import Subproduct, Key, TroveGame
 
 
 @pytest.fixture
@@ -27,25 +26,6 @@ def change_settings():
     def fn(plugin_mock, lib_config):
         plugin_mock._library_resolver._settings.update(lib_config)
     return fn
-
-
-@pytest.fixture
-def get_torchlight_trove(get_troves):
-    troves_data = get_troves(from_index=0)
-    for i in troves_data:
-        if i['machine_name'] == 'torchlight_trove':
-            trove_torchlight = i
-    return trove_torchlight, TroveGame(trove_torchlight)
-
-
-@pytest.fixture
-def get_torchlight(orders_keys):
-    for i in orders_keys:
-        if i['product']['machine_name'] == 'torchlight_storefront':
-            torchlight_order = i
-    drm_free = Subproduct(torchlight_order['subproducts'][0])
-    key = Key(torchlight_order['tpkd_dict']['all_tpks'][0])
-    return torchlight_order, drm_free, key
 
 
 @pytest.mark.asyncio

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -7,26 +7,7 @@ from unittest.mock import Mock
 from galaxy.api.errors import UnknownError
 
 from library import LibraryResolver
-from model.game import Key, Subproduct, TroveGame
-
-
-@pytest.fixture
-def get_torchlight_trove(get_troves):
-    troves_data = get_troves(from_index=0)
-    for i in troves_data:
-        if i['machine_name'] == 'torchlight_trove':
-            trove_torchlight = i
-    return trove_torchlight, TroveGame(trove_torchlight)
-
-
-@pytest.fixture
-def get_torchlight(orders_keys):
-    for i in orders_keys:
-        if i['product']['machine_name'] == 'torchlight_storefront':
-            torchlight_order = i
-    drm_free = Subproduct(torchlight_order['subproducts'][0])
-    key = Key(torchlight_order['tpkd_dict']['all_tpks'][0])
-    return torchlight_order, drm_free, key
+from model.game import Subproduct, Key, TroveGame
 
 
 @pytest.fixture
@@ -46,6 +27,25 @@ def change_settings():
     def fn(plugin_mock, lib_config):
         plugin_mock._library_resolver._settings.update(lib_config)
     return fn
+
+
+@pytest.fixture
+def get_torchlight_trove(get_troves):
+    troves_data = get_troves(from_index=0)
+    for i in troves_data:
+        if i['machine_name'] == 'torchlight_trove':
+            trove_torchlight = i
+    return trove_torchlight, TroveGame(trove_torchlight)
+
+
+@pytest.fixture
+def get_torchlight(orders_keys):
+    for i in orders_keys:
+        if i['product']['machine_name'] == 'torchlight_storefront':
+            torchlight_order = i
+    drm_free = Subproduct(torchlight_order['subproducts'][0])
+    key = Key(torchlight_order['tpkd_dict']['all_tpks'][0])
+    return torchlight_order, drm_free, key
 
 
 @pytest.mark.asyncio

--- a/tests/common/test_plugin.py
+++ b/tests/common/test_plugin.py
@@ -1,12 +1,13 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, Mock, PropertyMock
 import pathlib
 
 from galaxy.api.consts import OSCompatibility as OSC
+from galaxy.api.types import GameLibrarySettings
 
 from consts import HP, CURRENT_SYSTEM
 from local.localgame import LocalHumbleGame
-from model.game import Subproduct
+from model.game import Subproduct, KeyGame, TroveGame
 from humbledownloader import HumbleDownloadResolver
 
 
@@ -71,10 +72,29 @@ async def test_get_os_compatibility(plugin_mock, overgrowth):
     plugin_mock._owned_games= { ovg_id: game, no_downloads_id: no_dw_game}
 
     ctx = await plugin_mock.prepare_os_compatibility_context([ovg_id, no_downloads_id])
-    await plugin_mock.get_os_compatibility(no_downloads_id, ctx) == None
-    await plugin_mock.get_os_compatibility(ovg_id, ctx) == OSC.Windows | OSC.MacOS | OSC.Linux
+    assert await plugin_mock.get_os_compatibility(no_downloads_id, ctx) == None
+    assert await plugin_mock.get_os_compatibility(ovg_id, ctx) == OSC.Windows | OSC.MacOS | OSC.Linux
 
 
 @pytest.mark.asyncio
-async def test_library_settings(plugin_mock, get_torchlight_trove, get_torchlight):
-    pass
+async def test_library_settings_key(plugin_mock):
+    trove = Mock(spec=TroveGame)
+    drm_free = Mock(spec=Subproduct)
+    key = Mock(spec=KeyGame)
+    type(key).key_val = PropertyMock(return_value='COEO23DN')
+    unrevealed_key = Mock(spec=KeyGame)
+    type(unrevealed_key).key_val = PropertyMock(return_value=None)
+
+    plugin_mock._owned_games = {
+        'a': drm_free,
+        'b': trove,
+        'c': key,
+        'd': unrevealed_key
+    }
+
+    ctx = await plugin_mock.prepare_game_library_settings_context(['b', 'c', 'd', 'a'])
+    assert await plugin_mock.get_game_library_settings('a', ctx) == GameLibrarySettings('a', None, None)
+    assert await plugin_mock.get_game_library_settings('b', ctx) == GameLibrarySettings('b', ['Trove'], None)
+    assert await plugin_mock.get_game_library_settings('c', ctx) == GameLibrarySettings('c', ['Key'], None)
+    assert await plugin_mock.get_game_library_settings('d', ctx) == GameLibrarySettings('d', ['Key', 'Unrevealed'], None)
+    

--- a/tests/common/test_plugin.py
+++ b/tests/common/test_plugin.py
@@ -73,3 +73,8 @@ async def test_get_os_compatibility(plugin_mock, overgrowth):
     ctx = await plugin_mock.prepare_os_compatibility_context([ovg_id, no_downloads_id])
     await plugin_mock.get_os_compatibility(no_downloads_id, ctx) == None
     await plugin_mock.get_os_compatibility(ovg_id, ctx) == OSC.Windows | OSC.MacOS | OSC.Linux
+
+
+@pytest.mark.asyncio
+async def test_library_settings(plugin_mock, get_torchlight_trove, get_torchlight):
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(pathlib.PurePath(__file__).parent.parent / 'src'))
 from galaxy.api.errors import UnknownError
 from plugin import HumbleBundlePlugin
 from settings import Settings
+from model.game import Key, Subproduct, TroveGame
 
 
 class AsyncMock(MagicMock):
@@ -103,3 +104,22 @@ def get_troves(get_data):
             troves.extend(get_data(f'troves_{i + 1}.json'))
         return troves
     return fn
+
+
+@pytest.fixture
+def get_torchlight_trove(get_troves):
+    troves_data = get_troves(from_index=0)
+    for i in troves_data:
+        if i['machine_name'] == 'torchlight_trove':
+            trove_torchlight = i
+    return trove_torchlight, TroveGame(trove_torchlight)
+
+
+@pytest.fixture
+def get_torchlight(orders_keys):
+    for i in orders_keys:
+        if i['product']['machine_name'] == 'torchlight_storefront':
+            torchlight_order = i
+    drm_free = Subproduct(torchlight_order['subproducts'][0])
+    key = Key(torchlight_order['tpkd_dict']['all_tpks'][0])
+    return torchlight_order, drm_free, key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ sys.path.insert(0, str(pathlib.PurePath(__file__).parent.parent / 'src'))
 from galaxy.api.errors import UnknownError
 from plugin import HumbleBundlePlugin
 from settings import Settings
-from model.game import Key, Subproduct, TroveGame
 
 
 class AsyncMock(MagicMock):
@@ -104,22 +103,3 @@ def get_troves(get_data):
             troves.extend(get_data(f'troves_{i + 1}.json'))
         return troves
     return fn
-
-
-@pytest.fixture
-def get_torchlight_trove(get_troves):
-    troves_data = get_troves(from_index=0)
-    for i in troves_data:
-        if i['machine_name'] == 'torchlight_trove':
-            trove_torchlight = i
-    return trove_torchlight, TroveGame(trove_torchlight)
-
-
-@pytest.fixture
-def get_torchlight(orders_keys):
-    for i in orders_keys:
-        if i['product']['machine_name'] == 'torchlight_storefront':
-            torchlight_order = i
-    drm_free = Subproduct(torchlight_order['subproducts'][0])
-    key = Key(torchlight_order['tpkd_dict']['all_tpks'][0])
-    return torchlight_order, drm_free, key


### PR DESCRIPTION
Adds ability to import predefined tags: `Key`, `Unrevealed` and `Trove` to library.
They can be imported only manually by going to
`Settings` -> `Features` -> `Import` button under "HUMBLE BUNDLE"

Warning: this will not automatically add tags for newly appeared games. You have to reimport them again.

Implements #84 
