### PR TITLE
Throttle checking for owned games

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -5,7 +5,7 @@
 - psutil: security update to 5.6.6
 
 [Changed]
-- GUI: increased throttling of loading library settings to ~0.3/sec to protect Galaxy from expensive operations
+- GUI: rate of loading library settings decreased to ~0.3/sec to protect Galaxy from expensive operations #91
 
 ## Version 0.7.0
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -4,6 +4,9 @@
 - GUI: fix showing (add missing changelog) on stable branch
 - psutil: security update to 5.6.6
 
+[Changed]
+- GUI: increased throttling of loading library settings to ~0.3/sec to protect Galaxy from expensive operations
+
 ## Version 0.7.0
 
 [Added]


### PR DESCRIPTION
Increase throttle to protect Galaxy from fast and furious user's while when changing Library settings via GUI.