### PR TITLE
Signed drm-free download

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 [Added]
 - Graphical User Interface for configuration. It can be opened by double clicking "Install" button on any Humble game.
-- Ability to import predefined tags: `Key`, `Unrevealed` and `Trove` to library.Â This won't add tags for newly appeared games automatically. You have to reimport them manually by going to Settings -> Features -> Import button under "HUMBLE BUNDLE".
+- Ability to import predefined tags: `Key`, `Unrevealed` and `Trove` to library. This won't add tags for newly appeared games automatically. You have to reimport them manually by going to Settings -> Features -> Import button under "HUMBLE BUNDLE".
 - Support for keys containing multiple games at once.
 - Automatic updates to integration downloaded manually from https://github.com/UncleGoogle/galaxy-integration-humblebundle/releases (this is "latest" version channel - new versions come eariler but are less stable than integrtion downloaded via Galaxy)
 

--- a/src/humbledownloader.py
+++ b/src/humbledownloader.py
@@ -1,48 +1,23 @@
 from model.game import HumbleGame, TroveGame, Subproduct
-from model.download import DownloadStruct, SubproductDownload, TroveDownload
-from consts import CURRENT_SYSTEM, PlatformNotSupported, CURRENT_BITNESS, HP, BITNESS
+from model.download import DownloadStructItem, SubproductDownload, TroveDownload
+from consts import CURRENT_BITNESS, HP, BITNESS
 
 
 class HumbleDownloadResolver:
     """Prepares downloads for specific conditionals"""
-    def __init__(self, target_platform: HP=CURRENT_SYSTEM, target_bitness: BITNESS=CURRENT_BITNESS):
-        self.platform = target_platform
-        self.bitness = target_bitness
-
+    def __init__(self, target_bitness: BITNESS=CURRENT_BITNESS):
         if target_bitness == BITNESS.B64:
             self._expected_names = ['Download', '64-bit', '32-bit']
         else:
             self._expected_names = ['Download', '32-bit']
 
-    def __call__(self, game: HumbleGame) -> DownloadStruct:
-        if isinstance(game, TroveGame):
-            return self._find_best_trove_download(game)
-        elif isinstance(game, Subproduct):
-            return self._find_best_subproduct_download(game)
-        else:
-            raise AssertionError('Unsupported game type')
-
-    def _find_best_trove_download(self, game: TroveGame) -> TroveDownload:  # type: ignore[return]
-        try:
-            return game.downloads[self.platform]
-        except KeyError:
-            self.__platform_not_supported_handler(game)
-
-    def _find_best_subproduct_download(self, game: Subproduct) -> SubproductDownload:
-        try:
-            system_downloads = game.downloads[self.platform]
-        except KeyError:
-            self.__platform_not_supported_handler(game)
-
-        if len(system_downloads) == 1:
-            return system_downloads[0]
-
-        # choose download prioritizing lower indexes of self._expected_names
+    def __call__(self, download: SubproductDownload) -> DownloadStructItem:
+        download_struct = download.download_struct
+        if len(download_struct) == 1:
+            return download_struct[0]
+        # choose download struct prioritizing lower indexes of self._expected_names
         for name in self._expected_names:
-            for dw in system_downloads:
+            for dw in download_struct:
                 if name == dw.name:
                     return dw
-        raise NotImplementedError(f'Cannot decide which download to choose: {system_downloads}')
-
-    def __platform_not_supported_handler(self, game):
-        raise PlatformNotSupported(f'{game.human_name} has only downloads for {list(game.downloads.keys())}')
+        raise NotImplementedError(f'Cannot decide which download struct item to choose: {download_struct}')

--- a/src/model/download.py
+++ b/src/model/download.py
@@ -1,8 +1,7 @@
-import abc
-from typing import Optional
+from typing import Optional, List
 
 
-class DownloadStruct(abc.ABC):
+class DownloadStructItem():
     """
     url: Dict[str, str]         # {'bittorent': str, 'web': str}
     file_size: str
@@ -13,7 +12,7 @@ class DownloadStruct(abc.ABC):
     def __init__(self, data: dict):
         self._data = data
         self.url = data.get('url')
-    
+
     def __str__(self):
         return f"<{self.__class__.__name__}> '{self.name}'"
 
@@ -36,12 +35,12 @@ class DownloadStruct(abc.ABC):
             return None
         return self.url.get('bittorrent')
 
-    @abc.abstractmethod
+    @property
     def human_size(self) -> str:
-        pass
+        return self._data['human_size']
 
 
-class TroveDownload(DownloadStruct):
+class TroveDownload(DownloadStructItem):
     """ Additional fields:
     sha1: str
     timestamp: int          # ?
@@ -57,10 +56,18 @@ class TroveDownload(DownloadStruct):
         return self._data['machine_name']
 
 
-class SubproductDownload(DownloadStruct):
-    """ Additional fields:
-    human_size: str
-    """
+class SubproductDownload():
+    def __init__(self, data: dict):
+        self._data = data
+        self._download_struct = [
+            DownloadStructItem(x)
+            for x in data['download_struct']
+        ]
+
     @property
-    def human_size(self):
-        return self._data['human_size']
+    def machine_name(self) -> str:
+        return self._data['machine_name']
+
+    @property
+    def download_struct(self) -> List[DownloadStructItem]:
+        return self._download_struct

--- a/src/model/download.py
+++ b/src/model/download.py
@@ -48,11 +48,11 @@ class TroveDownload(DownloadStructItem):
     size: str
     """
     @property
-    def human_size(self):
+    def human_size(self) -> str:
         return self._data['size']
 
     @property
-    def machine_name(self):
+    def machine_name(self) -> str:
         return self._data['machine_name']
 
 

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -16,7 +16,7 @@ class HumbleGame(abc.ABC):
     def __init__(self, data: dict):
         self._data = data
         self._minimal_validation()
-    
+
     def _minimal_validation(self):
         try:
             self.in_galaxy_format()
@@ -52,7 +52,7 @@ class HumbleGame(abc.ABC):
 
     def __str__(self):
         return f"<{self.__class__.__name__}> {self.human_name} : {self.machine_name}"
-    
+
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
@@ -84,7 +84,7 @@ class TroveGame(HumbleGame):
 
 class Subproduct(HumbleGame):
     @property
-    def downloads(self) -> Dict[HP, List[SubproductDownload]]:
+    def downloads(self) -> Dict[HP, SubproductDownload]:
         result = {}
         for dw in self._data['downloads']:
             try:
@@ -92,10 +92,7 @@ class Subproduct(HumbleGame):
             except TypeError as e:
                 logging.warning(e, extra={'game': self._data})
             else:
-                result[os_] = [
-                    SubproductDownload(x)
-                    for x in dw['download_struct']
-                ]
+                result[os_] = SubproductDownload(dw)
         return result
 
     @property
@@ -131,7 +128,7 @@ class Key(HumbleGame):
     def key_val(self) -> Optional[str]:
         """If returned value is None - the key was not revealed yet"""
         return self._data.get('redeemed_key_val')
-    
+
     @property
     def key_games(self) -> List['KeyGame']:
         """One key can represent multiple games listed in human_name.
@@ -153,12 +150,12 @@ class KeyGame(Key):
         self._game_name = game_name
         self._game_id = game_id
         super().__init__(key._data)
-    
+
     @property
     def human_name(self):
         """Uses heuristics to add key identity if not already present.
         The heuristics may be wrong but it is not very harmfull."""
-        key_type = super().key_type_human_name 
+        key_type = super().key_type_human_name
         keywords = [" Key", key_type]
         for keyword in keywords:
             if keyword in self._game_name:

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -17,7 +17,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from galaxy.api.plugin import Plugin, create_and_run_plugin
 from galaxy.api.consts import Platform, OSCompatibility
 from galaxy.api.types import Authentication, NextStep, LocalGame, GameLibrarySettings
-from galaxy.api.errors import AuthenticationRequired, InvalidCredentials
+from galaxy.api.errors import AuthenticationRequired, InvalidCredentials, UnknownError
 
 from consts import HP, CURRENT_SYSTEM
 from settings import Settings
@@ -153,8 +153,8 @@ class HumbleBundlePlugin(Plugin):
     async def install_game(self, game_id):
         if game_id in self._under_installation:
             return
-        self._under_installation.add(game_id)
 
+        self._under_installation.add(game_id)
         try:
             game = self._owned_games.get(game_id)
             if game is None:
@@ -169,21 +169,28 @@ class HumbleBundlePlugin(Plugin):
                     webbrowser.open('https://www.humblebundle.com/home/keys')
                 return
 
-            chosen_download = self._download_resolver(game)
+            try:
+                curr_os_download = game.downloads[CURRENT_SYSTEM]
+            except KeyError:
+                raise UnknownError(f'{game.human_name} has only downloads for {list(game.downloads.keys())}')
+
             if isinstance(game, Subproduct):
-                webbrowser.open(chosen_download.web)
+                chosen_download_struct = self._download_resolver(curr_os_download)
+                urls = await self._api.get_subproduct_sign_url(chosen_download_struct, curr_os_download.machine_name)
+                webbrowser.open(urls['signed_url'])
 
             if isinstance(game, TroveGame):
                 try:
-                    url = await self._api.get_trove_sign_url(chosen_download, game.machine_name)
+                    urls = await self._api.get_trove_sign_url(curr_os_download, game.machine_name)
                 except AuthenticationRequired:
                     logging.info('Looks like your Humble Monthly subscription has expired.')
                     webbrowser.open('https://www.humblebundle.com/subscription/home')
                 else:
-                    webbrowser.open(url['signed_url'])
+                    webbrowser.open(urls['signed_url'])
 
         except Exception as e:
-            logging.exception(e, extra={'game': game})
+            logging.error(e, extra={'game': game})
+            raise
         finally:
             self._under_installation.remove(game_id)
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -176,12 +176,12 @@ class HumbleBundlePlugin(Plugin):
 
             if isinstance(game, Subproduct):
                 chosen_download_struct = self._download_resolver(curr_os_download)
-                urls = await self._api.get_subproduct_sign_url(chosen_download_struct, curr_os_download.machine_name)
+                urls = await self._api.sign_url_subproduct(chosen_download_struct, curr_os_download.machine_name)
                 webbrowser.open(urls['signed_url'])
 
             if isinstance(game, TroveGame):
                 try:
-                    urls = await self._api.get_trove_sign_url(curr_os_download, game.machine_name)
+                    urls = await self._api.sign_url_trove(curr_os_download, game.machine_name)
                 except AuthenticationRequired:
                     logging.info('Looks like your Humble Monthly subscription has expired.')
                     webbrowser.open('https://www.humblebundle.com/subscription/home')

--- a/src/webservice.py
+++ b/src/webservice.py
@@ -172,13 +172,17 @@ class AuthorizedHumbleAPI:
         return yarl.URL(link).parts[-1]
 
     async def get_subproduct_sign_url(self, download: DownloadStructItem, download_machine_name: str):
+        if download.web is None:
+            raise RuntimeError(f'No download web link in download struct item {download}')
         filename = self._filename_from_web_link(download.web)
         urls = await self._sign_download(download_machine_name, filename)
         await self.__reedem_download(
-            download.machine_name, {'download_url_file': filename})
+            download_machine_name, {'download_url_file': filename})
         return urls
 
     async def get_trove_sign_url(self, download: TroveDownload, product_machine_name: str):
+        if download.web is None:
+            raise RuntimeError(f'No download web link in download struct item {download}')
         urls = await self._sign_download(download.machine_name, download.web)
         await self.__reedem_download(
             download.machine_name, {'product': product_machine_name})

--- a/src/webservice.py
+++ b/src/webservice.py
@@ -165,7 +165,6 @@ class AuthorizedHumbleAPI:
         content = await res.read()
         if content != b"{'success': True}":
             logging.error(f'unexpected response while reedem trove download: {content}')
-            raise UnknownError()
 
     @staticmethod
     def _filename_from_web_link(link: str):

--- a/src/webservice.py
+++ b/src/webservice.py
@@ -145,14 +145,14 @@ class AuthorizedHumbleAPI:
             index += 1
         return troves
 
-    async def _sign_download(self, machine_name: str, filename: str):
+    async def sign_download(self, machine_name: str, filename: str):
         res = await self._request('post', self._DOWNLOAD_SIGN, params={
             'machine_name': machine_name,
             'filename': filename
         })
         return await res.json()
 
-    async def __reedem_download(self, download_machine_name: str, custom_data: dict):
+    async def _reedem_download(self, download_machine_name: str, custom_data: dict):
         """Unknown purpose - humble http client do this after post for signed_url
         Response should be text with {'success': True} if everything is OK
         """
@@ -170,24 +170,24 @@ class AuthorizedHumbleAPI:
     def _filename_from_web_link(link: str):
         return yarl.URL(link).parts[-1]
 
-    async def get_subproduct_sign_url(self, download: DownloadStructItem, download_machine_name: str):
+    async def sign_url_subproduct(self, download: DownloadStructItem, download_machine_name: str):
         if download.web is None:
             raise RuntimeError(f'No download web link in download struct item {download}')
         filename = self._filename_from_web_link(download.web)
-        urls = await self._sign_download(download_machine_name, filename)
+        urls = await self.sign_download(download_machine_name, filename)
         try:
-            await self.__reedem_download(
+            await self._reedem_download(
                 download_machine_name, {'download_url_file': filename})
         except Exception as e:
             logging.error(repr(e) + '. Error ignored')
         return urls
 
-    async def get_trove_sign_url(self, download: TroveDownload, product_machine_name: str):
+    async def sign_url_trove(self, download: TroveDownload, product_machine_name: str):
         if download.web is None:
             raise RuntimeError(f'No download web link in download struct item {download}')
-        urls = await self._sign_download(download.machine_name, download.web)
+        urls = await self.sign_download(download.machine_name, download.web)
         try:
-            await self.__reedem_download(
+            await self._reedem_download(
                 download.machine_name, {'product': product_machine_name})
         except Exception as e:
             logging.error(repr(e) + '. Error ignored')

--- a/tasks.py
+++ b/tasks.py
@@ -68,7 +68,7 @@ def build(c, output=DIST_PLUGIN):
         try:
             shutil.rmtree(output)
         except OSError as e:
-            if hasattr(e, 'winerror') and e.winerror in [145, 5]:
+            if hasattr(e, 'winerror') and e.winerror in [145, 5]:  # type: ignore
                 # something e.g. antivirus check holds a file. Try to wait to be released for a moment
                 time.sleep(3)
                 shutil.rmtree(output)

--- a/tests/common/model/test_game.py
+++ b/tests/common/model/test_game.py
@@ -8,9 +8,9 @@ def test_game_properties_overgrowth(overgrowth):
         sub.human_name
         sub.machine_name
         sub.license
-        for platform, download_structs in sub.downloads.items():
+        for platform, download in sub.downloads.items():
             assert platform in set(HP)
-            for dw_struct in download_structs:
+            for dw_struct in download.download_struct:
                 dw_struct.web
                 dw_struct.bittorrent
                 dw_struct.human_size
@@ -24,9 +24,9 @@ def test_game_properties_access(orders):
             sub.human_name
             sub.machine_name
             sub.license
-            for platform, download_structs in sub.downloads.items():
+            for platform, download in sub.downloads.items():
                 assert platform in set(HP)
-                for dw_struct in download_structs:
+                for dw_struct in download.download_struct:
                     dw_struct.web
                     dw_struct.bittorrent
                     dw_struct.human_size

--- a/tests/common/test_api.py
+++ b/tests/common/test_api.py
@@ -1,0 +1,7 @@
+from webservice import AuthorizedHumbleAPI
+
+
+def test_filename_from_web_link():
+    web_link = 'https://dl.humble.com/Almost_There_Windows.zip?gamekey=AbR9TcsD4ecueNGw&ttl=1587335864&t=a04a9b4f6512b7958f6357cb7b628452'
+    expected = 'Almost_There_Windows.zip'
+    assert expected == AuthorizedHumbleAPI._filename_from_web_link(web_link)

--- a/tests/common/test_appfinder.py
+++ b/tests/common/test_appfinder.py
@@ -12,7 +12,7 @@ from consts import IS_WINDOWS
 def candidates():
     """Bunch of owned game names that are candidates for matching algorithm"""
     return set(
-        ['Dummy', 'Trine 2: Complete Story', 'Space Pilgrim Episode III: Delta Pavonis', 'Halcyon 6: LIGHTSPEED EDITION', 'Shank 2', 'AaaaaAAaaaAAAaaAAAAaAAAAA!!! for the Awesome']
+        ['Dummy', 'Haven Moon - DRM free', 'Trine 2: Complete Story', 'Space Pilgrim Episode III: Delta Pavonis', 'Halcyon 6: LIGHTSPEED EDITION', 'Shank 2', 'AaaaaAAaaaAAAaaAAAAaAAAAA!!! for the Awesome']
     )
 
 

--- a/tests/common/test_downloader.py
+++ b/tests/common/test_downloader.py
@@ -1,49 +1,19 @@
-import pytest
-
 from humbledownloader import HumbleDownloadResolver
-from model.game import Subproduct, TroveGame
-from consts import HP, BITNESS
+from model.download import SubproductDownload
+from consts import BITNESS
 
 
-@pytest.mark.parametrize("platform,bitness", [(HP.WINDOWS, BITNESS.B64), (HP.WINDOWS, BITNESS.B32), (HP.MAC, BITNESS.B64)])
-def test_any_download_found(orders, get_troves, platform, bitness):
-    """Test choosing proper download"""
-    download_resolver = HumbleDownloadResolver(platform, bitness)
-
-    for order in orders:
-        for sub_data in order['subproducts']:
-            sub = Subproduct(sub_data)
-            if not sub.os_compatibile(platform):
-                continue
-            try:
-                download_resolver(sub) 
-            except NotImplementedError as e:
-                pytest.fail('Unresolved download: ' + str(e))
-
-    for trove_data in get_troves(from_index=0):
-        trove = TroveGame(trove_data)
-        if not trove.os_compatibile(platform):
-            continue
-        download_resolver(trove)
-
-
-def test_windows_bitness_priority():
-    subproduct_data = {
-        'machine_name': 'test',
-        'human_name': 'TEST',
-        'downloads': [
-            {
-                'platform': 'windows',
-                'machine_name': 'test_dw',
-                'download_struct': [
-                    { 'name': '32-bit' },
-                    { 'name': '64-bit' }
-                ]
-            }
+def test_download_resolver_for_bitness():
+    data = {
+        'platform': 'windows',
+        'machine_name': 'test_dw',
+        'download_struct': [
+            { 'name': '32-bit' },
+            { 'name': '64-bit' }
         ]
     }
-    sub = Subproduct(subproduct_data)
-    download = HumbleDownloadResolver(HP.WINDOWS, BITNESS.B64)(sub)
+    sub = SubproductDownload(data)
+    download = HumbleDownloadResolver(BITNESS.B64)(sub)
     assert download.name == '64-bit'
-    download = HumbleDownloadResolver(HP.WINDOWS, BITNESS.B32)(sub)
+    download = HumbleDownloadResolver(BITNESS.B32)(sub)
     assert download.name == '32-bit'

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -13,21 +13,21 @@ from model.game import Subproduct, Key, TroveGame
 
 
 @pytest.fixture
-def create_resolver(plugin_mock):
+def create_resolver(plugin):
     def fn(settings, cache={}):
         return LibraryResolver(
-            api=plugin_mock._api,
+            api=plugin._api,
             settings=settings,
             cache=cache,
-            save_cache_callback=partial(plugin_mock._save_cache, 'library')
+            save_cache_callback=partial(plugin._save_cache, 'library')
         )
     return fn
 
 
 @pytest.fixture
 def change_settings():
-    def fn(plugin_mock, lib_config):
-        plugin_mock._library_resolver._settings.update(lib_config)
+    def fn(plugin, lib_config):
+        plugin._library_resolver._settings.update(lib_config)
     return fn
 
 
@@ -83,111 +83,111 @@ async def test_library_cache_trove(create_resolver, get_torchlight_trove):
 # ------ library: fetching info from API ---------
 
 @pytest.mark.asyncio
-async def test_library_trove(plugin_mock, get_torchlight_trove, change_settings):
+async def test_library_trove(plugin, get_torchlight_trove, change_settings):
     trove_torch_data, trove = get_torchlight_trove
 
-    change_settings(plugin_mock, {'sources': ['trove']})
-    result = await plugin_mock._library_resolver()
+    change_settings(plugin, {'sources': ['trove']})
+    result = await plugin._library_resolver()
     assert result[trove.machine_name] == trove
-    assert trove_torch_data in json.loads(plugin_mock.persistent_cache['library'])['troves']
+    assert trove_torch_data in json.loads(plugin.persistent_cache['library'])['troves']
 
     # cache and calls to api
-    assert plugin_mock._api.get_gamekeys.call_count == 0  # only troves are checked
-    assert plugin_mock._api.get_order_details.call_count == 0
-    assert plugin_mock._api.get_trove_details.call_count == 1  # from chunk no. 0
+    assert plugin._api.get_gamekeys.call_count == 0  # only troves are checked
+    assert plugin._api.get_order_details.call_count == 0
+    assert plugin._api.get_trove_details.call_count == 1  # from chunk no. 0
 
 
 @pytest.mark.asyncio
-async def test_library_cache_orders(plugin_mock, get_torchlight, change_settings):
+async def test_library_cache_orders(plugin, get_torchlight, change_settings):
     _, drm_free, key = get_torchlight
 
-    change_settings(plugin_mock, {'sources': ['drm-free'], 'show_revealed_keys': True})
-    result = await plugin_mock._library_resolver()
+    change_settings(plugin, {'sources': ['drm-free'], 'show_revealed_keys': True})
+    result = await plugin._library_resolver()
     assert result[drm_free.machine_name] == drm_free
 
-    plugin_mock._api.get_gamekeys.reset_mock()
-    plugin_mock._api.get_order_details.reset_mock()
+    plugin._api.get_gamekeys.reset_mock()
+    plugin._api.get_order_details.reset_mock()
 
-    change_settings(plugin_mock, {'sources': ['keys']})
-    result = await plugin_mock._library_resolver(only_cache=True)
+    change_settings(plugin, {'sources': ['keys']})
+    result = await plugin._library_resolver(only_cache=True)
     assert result[key.machine_name] == key.key_games[0]
     assert drm_free.machine_name not in result
     # no api calls if cache used
-    assert plugin_mock._api.get_gamekeys.call_count == 0
-    assert plugin_mock._api.get_order_details.call_count == 0
-    
+    assert plugin._api.get_gamekeys.call_count == 0
+    assert plugin._api.get_order_details.call_count == 0
+
 
 @pytest.mark.asyncio
-async def test_library_fetch_with_cache_orders(plugin_mock, get_torchlight, change_settings):
+async def test_library_fetch_with_cache_orders(plugin, get_torchlight, change_settings):
     """Refresh reveals keys only if needed"""
     torchlight, _, key = get_torchlight
 
-    change_settings(plugin_mock, {'sources': ['keys'], 'show_revealed_keys': False})
-    result = await plugin_mock._library_resolver()
+    change_settings(plugin, {'sources': ['keys'], 'show_revealed_keys': False})
+    result = await plugin._library_resolver()
 
     # reveal all keys in torchlight order
-    for i in plugin_mock._api.orders:
+    for i in plugin._api.orders:
         if i == torchlight:
             for tpk in i['tpkd_dict']['all_tpks']:
                 tpk['redeemed_key_val'] = 'redeemed mock code'
             break
     # Get orders that has at least one unrevealed key
     unrevealed_order_keys = []
-    for i in plugin_mock._api.orders:
+    for i in plugin._api.orders:
         if any(('redeemed_key_val' not in x for x in i['tpkd_dict']['all_tpks'])):
             unrevealed_order_keys.append(i['gamekey'])
 
     # reset mocks
-    plugin_mock._api.get_gamekeys.reset_mock()
-    plugin_mock._api.get_order_details.reset_mock()
+    plugin._api.get_gamekeys.reset_mock()
+    plugin._api.get_order_details.reset_mock()
 
     # cache "fetch_in" time has not passed:
     # refresh only orders that may change - those with any unrevealed key
-    change_settings(plugin_mock, {'sources': ['keys'], 'show_revealed_keys': False})
-    result = await plugin_mock._library_resolver()
+    change_settings(plugin, {'sources': ['keys'], 'show_revealed_keys': False})
+    result = await plugin._library_resolver()
     assert key.machine_name not in result  # revealed -> removed
-    assert plugin_mock._api.get_gamekeys.call_count == 1
-    assert plugin_mock._api.get_order_details.call_count == len(unrevealed_order_keys)
-    
+    assert plugin._api.get_gamekeys.call_count == 1
+    assert plugin._api.get_order_details.call_count == len(unrevealed_order_keys)
+
 
 @pytest.mark.asyncio
-async def test_library_cache_period(plugin_mock, change_settings, orders_keys):
+async def test_library_cache_period(plugin, change_settings, orders_keys):
     """Refresh reveals keys only if needed"""
-    change_settings(plugin_mock, {'sources': ['keys', 'trove'], 'show_revealed_keys': False})
+    change_settings(plugin, {'sources': ['keys', 'trove'], 'show_revealed_keys': False})
 
-    # set expired next fetch 
-    plugin_mock._library_resolver._cache['next_fetch_orders'] = time.time() - 10
-    plugin_mock._library_resolver._cache['next_fetch_troves'] = time.time() - 10
+    # set expired next fetch
+    plugin._library_resolver._cache['next_fetch_orders'] = time.time() - 10
+    plugin._library_resolver._cache['next_fetch_troves'] = time.time() - 10
 
     # cache "fetch_in" time has passed: refresh all
-    await plugin_mock._library_resolver()
-    assert plugin_mock._api.get_gamekeys.call_count == 1
-    assert plugin_mock._api.get_trove_details.call_count == 1
-    assert plugin_mock._api.get_order_details.call_count == len(orders_keys)
-    assert plugin_mock._api.had_trove_subscription.call_count == 1
+    await plugin._library_resolver()
+    assert plugin._api.get_gamekeys.call_count == 1
+    assert plugin._api.get_trove_details.call_count == 1
+    assert plugin._api.get_order_details.call_count == len(orders_keys)
+    assert plugin._api.had_trove_subscription.call_count == 1
 
 
 # --------test fetching orders-------------------
 
 @pytest.mark.asyncio
-async def test_fetch_orders_filter_errors_ok(plugin_mock, create_resolver):
+async def test_fetch_orders_filter_errors_ok(plugin, create_resolver):
     resolver = create_resolver(Mock())
     await resolver._fetch_orders([])
 
 @pytest.mark.asyncio
-async def test_fetch_orders_filter_errors_all_bad(plugin_mock, create_resolver):
+async def test_fetch_orders_filter_errors_all_bad(plugin, create_resolver):
     resolver = create_resolver(Mock())
-    plugin_mock._api.get_gamekeys.return_value = ['this_will_give_UnknownError', 'this_too']
+    plugin._api.get_gamekeys.return_value = ['this_will_give_UnknownError', 'this_too']
     with pytest.raises(UnknownError):
         await resolver._fetch_orders([])
 
 @pytest.mark.asyncio
-async def test_fetch_orders_filter_errors_one_404(plugin_mock, create_resolver, caplog):
+async def test_fetch_orders_filter_errors_one_404(plugin, create_resolver, caplog):
     """404 for specific order key"""
     resolver = create_resolver(Mock())
     resolver = create_resolver(Mock())
-    real_gamekeys = await plugin_mock._api.get_gamekeys()
-    plugin_mock._api.get_gamekeys.return_value = [real_gamekeys[0], 'this_will_give_UnknownError']
+    real_gamekeys = await plugin._api.get_gamekeys()
+    plugin._api.get_gamekeys.return_value = [real_gamekeys[0], 'this_will_give_UnknownError']
     caplog.clear()
     orders = await resolver._fetch_orders([])
     assert len(orders) == 1

--- a/tests/common/test_opening_options.py
+++ b/tests/common/test_opening_options.py
@@ -14,35 +14,35 @@ def auth_cookie():
 
 
 @pytest.mark.asyncio
-async def test_open_news_on_minor_update(plugin_mock, auth_cookie, mocker):
-    plugin_mock._open_config = MagicMock(spec=())
-    plugin_mock._last_version = '0.6.1'
+async def test_open_news_on_minor_update(plugin, auth_cookie, mocker):
+    plugin._open_config = MagicMock(spec=())
+    plugin._last_version = '0.6.1'
     mocker.patch('plugin.__version__', '0.7.0')
-    await plugin_mock.authenticate(stored_credentials=auth_cookie)
-    plugin_mock._open_config.assert_called_once_with(OPTIONS_MODE.NEWS)
+    await plugin.authenticate(stored_credentials=auth_cookie)
+    plugin._open_config.assert_called_once_with(OPTIONS_MODE.NEWS)
 
 
 @pytest.mark.asyncio
-async def test_do_not_open_news_on_patch_update(plugin_mock, auth_cookie, mocker):
-    plugin_mock._open_config = MagicMock(spec=())
-    plugin_mock._last_version = '0.7.0'
+async def test_do_not_open_news_on_patch_update(plugin, auth_cookie, mocker):
+    plugin._open_config = MagicMock(spec=())
+    plugin._last_version = '0.7.0'
     mocker.patch('plugin.__version__', '0.7.1')
-    await plugin_mock.authenticate(stored_credentials=auth_cookie)
-    plugin_mock._open_config.assert_not_called()
+    await plugin.authenticate(stored_credentials=auth_cookie)
+    plugin._open_config.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_open_welcome_on_authenticate(plugin_mock, auth_cookie):
-    plugin_mock._open_config = MagicMock(spec=())
-    await plugin_mock.pass_login_credentials('step', 'credentials', [auth_cookie])
-    plugin_mock._open_config.assert_called_once_with(OPTIONS_MODE.WELCOME)
+async def test_open_welcome_on_authenticate(plugin, auth_cookie):
+    plugin._open_config = MagicMock(spec=())
+    await plugin.pass_login_credentials('step', 'credentials', [auth_cookie])
+    plugin._open_config.assert_called_once_with(OPTIONS_MODE.WELCOME)
 
 
 @pytest.mark.asyncio
-async def test_open_options_on_clicking_install(plugin_mock, delayed_fn):
-    plugin_mock._open_config = MagicMock(spec=())
+async def test_open_options_on_clicking_install(plugin, delayed_fn):
+    plugin._open_config = MagicMock(spec=())
     await asyncio.gather(
-        delayed_fn(0.1, plugin_mock.install_game),
-        delayed_fn(0.2, plugin_mock.install_game)
+        delayed_fn(0.1, plugin.install_game),
+        delayed_fn(0.2, plugin.install_game)
     )
-    plugin_mock._open_config.assert_called_once()
+    plugin._open_config.assert_called_once()

--- a/tests/common/test_plugin.py
+++ b/tests/common/test_plugin.py
@@ -44,7 +44,7 @@ async def test_install_game_drm_free(api_mock, plugin, overgrowth):
     game = Subproduct(subproduct)
     plugin._owned_games = { id_: game }
     expected_url = "https://dl.humble.com/wolfiregames/overgrowth-1.4.0_build-5584-win64.zip?gamekey=XrCTukcAFwsh&ttl=1563893021&t=7f2263e7f3360f3beb112e58521145a0"
-    api_mock.get_subproduct_sign_url.return_value = {
+    api_mock.sign_url_subproduct.return_value = {
         "signed_url": expected_url
     }
 
@@ -59,7 +59,7 @@ async def test_install_game_trove(api_mock, plugin):
     game = Mock(spec=TroveGame, downloads={CURRENT_SYSTEM: Mock(spec=TroveDownload)})
     plugin._owned_games = { id_: game }
     expected_url = "https://dl.humble.com/developer/trove_game_012_build-5584-win64.zip?gamekey=XrCTukcAFwsh&ttl=1563893021&t=7f2263e7f3360f3beb112e58521145a0"
-    api_mock.get_trove_sign_url.return_value = {
+    api_mock.sign_url_trove.return_value = {
         "signed_url": expected_url
     }
 

--- a/tests/common/test_plugin.py
+++ b/tests/common/test_plugin.py
@@ -8,17 +8,18 @@ from galaxy.api.types import GameLibrarySettings
 from consts import HP, CURRENT_SYSTEM
 from local.localgame import LocalHumbleGame
 from model.game import Subproduct, KeyGame, TroveGame
+from model.download import TroveDownload
 
 
 @pytest.mark.asyncio
-async def test_launch_game(plugin_mock, overgrowth):
+async def test_launch_game(plugin, overgrowth):
     id_ = overgrowth['product']['machine_name']
-    plugin_mock._local_games = {
+    plugin._local_games = {
         id_: LocalHumbleGame(id_, pathlib.Path('game_dir') /  'mock.exe')
     }
     with patch('subprocess.Popen') as subproc:
         with patch('psutil.Process'):
-            await plugin_mock.launch_game(id_)
+            await plugin.launch_game(id_)
             if CURRENT_SYSTEM == HP.WINDOWS:
                 subproc.assert_called_once_with('game_dir\\mock.exe', creationflags=8 ,cwd=pathlib.Path('game_dir'))
             elif CURRENT_SYSTEM == HP.MAC:
@@ -26,34 +27,49 @@ async def test_launch_game(plugin_mock, overgrowth):
 
 
 @pytest.mark.asyncio
-async def test_uninstall_game(plugin_mock, overgrowth):
+async def test_uninstall_game(plugin, overgrowth):
     id_ = overgrowth['product']['machine_name']
-    plugin_mock._local_games = {
+    plugin._local_games = {
         id_: LocalHumbleGame(id_, '', uninstall_cmd="unins000.exe")
     }
     with patch('subprocess.Popen') as subproc:
-        await plugin_mock.uninstall_game(id_)
+        await plugin.uninstall_game(id_)
         subproc.assert_called_once_with('unins000.exe')
 
 
 @pytest.mark.asyncio
-async def test_install_game_drm_free(api_mock, plugin_mock, overgrowth):
+async def test_install_game_drm_free(api_mock, plugin, overgrowth):
     id_ = overgrowth['product']['machine_name']
     subproduct = overgrowth['subproducts'][0]
     game = Subproduct(subproduct)
-    plugin_mock._owned_games = { id_: game }
+    plugin._owned_games = { id_: game }
     expected_url = "https://dl.humble.com/wolfiregames/overgrowth-1.4.0_build-5584-win64.zip?gamekey=XrCTukcAFwsh&ttl=1563893021&t=7f2263e7f3360f3beb112e58521145a0"
     api_mock.get_subproduct_sign_url.return_value = {
         "signed_url": expected_url
     }
 
     with patch('webbrowser.open') as browser_open:
-        await plugin_mock.install_game(id_)
+        await plugin.install_game(id_)
         browser_open.assert_called_once_with(expected_url)
 
 
 @pytest.mark.asyncio
-async def test_get_os_compatibility(plugin_mock, overgrowth):
+async def test_install_game_trove(api_mock, plugin):
+    id_ = 'trove_game'
+    game = Mock(spec=TroveGame, downloads={CURRENT_SYSTEM: Mock(spec=TroveDownload)})
+    plugin._owned_games = { id_: game }
+    expected_url = "https://dl.humble.com/developer/trove_game_012_build-5584-win64.zip?gamekey=XrCTukcAFwsh&ttl=1563893021&t=7f2263e7f3360f3beb112e58521145a0"
+    api_mock.get_trove_sign_url.return_value = {
+        "signed_url": expected_url
+    }
+
+    with patch('webbrowser.open') as browser_open:
+        await plugin.install_game(id_)
+        browser_open.assert_called_once_with(expected_url)
+
+
+@pytest.mark.asyncio
+async def test_get_os_compatibility(plugin, overgrowth):
     ovg_id = overgrowth['product']['machine_name']
     subproduct = overgrowth['subproducts'][0]
     game = Subproduct(subproduct)
@@ -64,15 +80,15 @@ async def test_get_os_compatibility(plugin_mock, overgrowth):
         'machine_name': no_downloads_id,
         'downloads': []
     })
-    plugin_mock._owned_games= { ovg_id: game, no_downloads_id: no_dw_game}
+    plugin._owned_games= { ovg_id: game, no_downloads_id: no_dw_game}
 
-    ctx = await plugin_mock.prepare_os_compatibility_context([ovg_id, no_downloads_id])
-    assert await plugin_mock.get_os_compatibility(no_downloads_id, ctx) == None
-    assert await plugin_mock.get_os_compatibility(ovg_id, ctx) == OSC.Windows | OSC.MacOS | OSC.Linux
+    ctx = await plugin.prepare_os_compatibility_context([ovg_id, no_downloads_id])
+    assert await plugin.get_os_compatibility(no_downloads_id, ctx) == None
+    assert await plugin.get_os_compatibility(ovg_id, ctx) == OSC.Windows | OSC.MacOS | OSC.Linux
 
 
 @pytest.mark.asyncio
-async def test_library_settings_key(plugin_mock):
+async def test_library_settings_key(plugin):
     trove = Mock(spec=TroveGame)
     drm_free = Mock(spec=Subproduct)
     key = Mock(spec=KeyGame)
@@ -80,15 +96,15 @@ async def test_library_settings_key(plugin_mock):
     unrevealed_key = Mock(spec=KeyGame)
     type(unrevealed_key).key_val = PropertyMock(return_value=None)
 
-    plugin_mock._owned_games = {
+    plugin._owned_games = {
         'a': drm_free,
         'b': trove,
         'c': key,
         'd': unrevealed_key
     }
 
-    ctx = await plugin_mock.prepare_game_library_settings_context(['b', 'c', 'd', 'a'])
-    assert await plugin_mock.get_game_library_settings('a', ctx) == GameLibrarySettings('a', None, None)
-    assert await plugin_mock.get_game_library_settings('b', ctx) == GameLibrarySettings('b', ['Trove'], None)
-    assert await plugin_mock.get_game_library_settings('c', ctx) == GameLibrarySettings('c', ['Key'], None)
-    assert await plugin_mock.get_game_library_settings('d', ctx) == GameLibrarySettings('d', ['Key', 'Unrevealed'], None)
+    ctx = await plugin.prepare_game_library_settings_context(['b', 'c', 'd', 'a'])
+    assert await plugin.get_game_library_settings('a', ctx) == GameLibrarySettings('a', None, None)
+    assert await plugin.get_game_library_settings('b', ctx) == GameLibrarySettings('b', ['Trove'], None)
+    assert await plugin.get_game_library_settings('c', ctx) == GameLibrarySettings('c', ['Key'], None)
+    assert await plugin.get_game_library_settings('d', ctx) == GameLibrarySettings('d', ['Key', 'Unrevealed'], None)

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -16,7 +16,7 @@ class MockSection(UpdateTracker):
         if type(self.key) != type(key):
             raise TypeError
         self.key = key
-    
+
     def serialize(self):
         return self.key
 
@@ -96,7 +96,7 @@ def test_installed_from_raw_file_allowed_paths(mocker):
         search_dirs = [
             'C:\Program Files(x86)\Humble',
             'D:\\Games',
-            "E:\\Games",
+            "Z:\\Games",
         ]
     """
     mocker.patch.object(Path, 'exists', return_value=True)
@@ -105,7 +105,7 @@ def test_installed_from_raw_file_allowed_paths(mocker):
         assert settings.installed.search_dirs == {
             Path("C:\\Program Files(x86)\\Humble"),
             Path("D:\\Games"),
-            Path("E:\\Games")
+            Path("Z:\\Games")
         }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,8 @@ def api_mock_raw():
     mock.get_order_details = AsyncMock()
     mock.get_gamekeys = AsyncMock()
     mock.had_trove_subscription = AsyncMock()
-    mock.get_trove_sign_url = AsyncMock()
     mock.get_trove_details = AsyncMock()
+    mock.get_trove_sign_url = AsyncMock()
     mock.get_subproduct_sign_url = AsyncMock()
     mock.close_session = AsyncMock()
     return mock
@@ -70,7 +70,7 @@ def api_mock(api_mock_raw, orders_keys, get_troves):
 
 
 @pytest.fixture
-async def plugin_mock(api_mock, settings, mocker):
+async def plugin(api_mock, settings, mocker):
     mocker.patch('plugin.AuthorizedHumbleAPI', return_value=api_mock)
     mocker.patch('settings.Settings', return_value=settings)
     plugin = HumbleBundlePlugin(Mock(), Mock(), "handshake_token")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def settings(mocker):
     mocker.patch('plugin.Settings._load_config_file')
     mock = Settings()
     mock.save_config = Mock()
-    return mock 
+    return mock
 
 
 @pytest.fixture
@@ -43,6 +43,7 @@ def api_mock_raw():
     mock.had_trove_subscription = AsyncMock()
     mock.get_trove_sign_url = AsyncMock()
     mock.get_trove_details = AsyncMock()
+    mock.get_subproduct_sign_url = AsyncMock()
     mock.close_session = AsyncMock()
     return mock
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,8 @@ def api_mock_raw():
     mock.get_gamekeys = AsyncMock()
     mock.had_trove_subscription = AsyncMock()
     mock.get_trove_details = AsyncMock()
-    mock.get_trove_sign_url = AsyncMock()
-    mock.get_subproduct_sign_url = AsyncMock()
+    mock.sign_url_trove = AsyncMock()
+    mock.sign_url_subproduct = AsyncMock()
     mock.close_session = AsyncMock()
     return mock
 


### PR DESCRIPTION
Fixes #94 
Instead of relying on download url links from orders API response, get fresh url by POSTing to `api/v1/user/download/sign`

Additionally send POST to `humbler/redeemdownload` (unknown purpose, but humblebundle.com webapp does it ¯\\_(ツ)_/¯

Suppress #96