### PR TITLE
Installed games detection: Limit executable serach to root level

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+[Changed]
+- Installed games detection: limit executable search to root level #119
+
+
 ## Version 0.8.0 Alpha (pre-release)
 [Fixed]
 - Downloading DRM-free games #97

--- a/src/local/pathfinder.py
+++ b/src/local/pathfinder.py
@@ -21,6 +21,7 @@ class PathFinder:
                 whole_path = os.path.join(root, path)
                 if self.is_exe(whole_path):
                     execs.append(whole_path)
+            break
         return execs
 
     def is_exe(self, path: str) -> bool:


### PR DESCRIPTION
Resolves #118 

Do not serach for executables in all found game directory tree.

As it was seen in mentioned issue, recursive search for executable can take too long time at once (then plugin "crash") and quite long for all installed games (like 2min). It should be enough to look only in base directory level as most Windows Games have executable "on top". MacOS games have its own parser.

I'll investigate later on if there is legitimate request to serach deeper.

Note: this is BREAKING CHANGE, but important to release before 1.0