### PR TITLE
Add start_time for subscription games from Trove

### DIFF
--- a/src/model/game.py
+++ b/src/model/game.py
@@ -61,15 +61,25 @@ class TroveGame(HumbleGame):
     def human_name(self):
         return self._data['human-name']
 
+    @property
+    def date_added(self) -> Optional[int]:
+        try:
+            return int(self._data['date-added'])
+        except (ValueError, KeyError):  # extra safety in case of changed format
+            return None
+
     def in_galaxy_format(self):
-        return SubscriptionGame(game_title=self.human_name, game_id=self.machine_name)
+        return SubscriptionGame(game_title=self.human_name, game_id=self.machine_name, start_time=self.date_added)
 
     def serialize(self):
-        return {
+        data = {
             'human-name': self._data['human-name'],
             'machine_name': self._data['machine_name'],
-            'downloads': self._data['downloads']
+            'downloads': self._data['downloads'],
         }
+        if 'date-added' in self._data:
+            data['date-added'] = self._data['date-added']
+        return data
 
 
 class Subproduct(HumbleGame):

--- a/tests/common/test_subscription_games.py
+++ b/tests/common/test_subscription_games.py
@@ -60,12 +60,12 @@ async def test_trove(api_mock, plugin):
 async def test_trove_store_in_presistent_cache(plugin):
     plugin.push_cache.reset_mock()
     plugin._trove_games = {
-        'a': TroveGame({'human-name': 'A', 'machine_name': 'a', 'downloads': {'windows': {}}}),
+        'a': TroveGame({'human-name': 'A', 'machine_name': 'a', 'downloads': {'windows': {}}, 'date-added': 123456789}),
         'c': TroveGame({'human-name': 'C', 'machine_name': 'c', 'downloads': {'mac': {}}}),
     }
     plugin.subscription_games_import_complete()
     assert plugin.persistent_cache['trove_games'] == '[' \
-        '{"human-name": "A", "machine_name": "a", "downloads": {"windows": {}}}, ' \
+        '{"human-name": "A", "machine_name": "a", "downloads": {"windows": {}}, "date-added": 123456789}, ' \
         '{"human-name": "C", "machine_name": "c", "downloads": {"mac": {}}}' \
     ']'
     plugin.push_cache.assert_called()


### PR DESCRIPTION
I've discovered that there is timestamp "date_added" for games from trove API.

Currently Galaxy does not use this information but maybe useful in the future.