### PR TITLE
Multi bundle split fix

### DIFF
--- a/src/library.py
+++ b/src/library.py
@@ -153,10 +153,14 @@ class LibraryResolver:
         """Extract list of KeyGame objects from single Key"""
         logger.info(f'Spliting {key}')
         names = key.human_name.split(', ')
-        return [
-            KeyGame(key, f'{key.machine_name}_{i}', name)
-            for i, name in enumerate(names)
-        ]
+        games = []
+
+        for i, name in enumerate(names):
+            # Multi-game packs have the word "and" in front of the last game name
+            first, _, rest = name.partition(" ")
+            if first == "and": name = rest or first
+            games.append(KeyGame(key, f'{key.machine_name}_{i}', name))
+        return games
 
     @staticmethod
     def _get_key_infos(orders: list) -> List[KeyInfo]:

--- a/src/library.py
+++ b/src/library.py
@@ -142,8 +142,8 @@ class LibraryResolver:
             return False
         if ', ' not in key.human_name:
             return False
-        for i in blacklist:
-            if i in key.human_name:
+        for i in map(str.casefold, blacklist):
+            if i in key.human_name.casefold():
                 logger.debug(f'{key} split blacklisted by "{i}"')
                 return False
         return True

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -190,6 +190,25 @@ def test_split_multigame_key():
         KeyGame(key, "sega_3", "Hell Yeah! Wrath of the Dead Rabbit")
     ]
 
+@pytest.mark.parametrize('machine_name, human_name, expected', [
+    ('deepsilver_bundle_initial_steam', 'Metro 2033, Risen, and Sacred Citadel', ['Metro 2033', 'Risen', 'Sacred Citadel']),
+    ('test_bundle_a', 'Some Game, Ori and Blind Forest', ['Some Game', 'Ori and Blind Forest']),
+    ('test_bundle_b', 'Some Game 1, and Some Game 2, and One More', ['Some Game 1', 'Some Game 2', 'One More']),
+    ('test_bundle_c', 'Game 1, And Yet It Moves', ['Game 1', 'And Yet It Moves']),
+    ('test_bundle_d', 'And Yet It Moves, and And Yet It Moves', ['And Yet It Moves', 'And Yet It Moves']),
+])
+def test_split_multigame_key_and(machine_name, human_name, expected):
+    # Many bundle keys add the word 'and' before the last game title
+    tpks = {
+        "machine_name": machine_name,
+        "human_name": human_name,
+    }
+    key = Key(tpks)
+    key_games = LibraryResolver._split_multigame_key(key)
+    assert len(key_games) == len(expected)
+
+    for idx in range(0, len(expected)):
+        assert key_games[idx] == KeyGame(key, f'{key.machine_name}_{idx}', expected[idx])
 
 def test_get_key_info():
     key_data_1 = {

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -166,6 +166,7 @@ async def test_fetch_orders_filter_errors_one_404(plugin, create_resolver, caplo
     ('Gremlins, Inc.', 'bundle', ['Here, there', 'Gremlins, I'], False),  # blacklisted
     ('Gremlins, Inc.', 'bundle', ['Here, there', 'Gremlins, no match'], True),
     ('Alpha Protocol, Company of Heroes, Rome: Total War, Hell Yeah! Wrath of the Dead Rabbit', 'bundle', [], True),
+    ('Star Wars™ Battlefront™ II (Classic, 2005)', 'bundle', ['STAR WARS™ Battlefront™ II (Classic, 2005)'], False),
 ])
 def test_is_multigame_key(human_name, category, blacklist, is_multigame):
     """Most common case where 1 key == 1 game"""


### PR DESCRIPTION
There are many bundles, such as the Deep Silver Bundle, which include the word "and" in the title string for the multi-game key bundle.
One example is: _Metro 2033, Risen, and Sacred Citadel_
This caused Galaxy to add a game called "and Sacred Citadel" to my list.

I added an extra check in the split code to check for the word "and", in lowercase. From what I've seen, that title isn't localized, and is always in English.

There's a second minor fix in there, which is for the blacklist. The Star Wars games recently had their titles changed when Disney bought the franchise and started releasing updates again. Battlefront and Battlefront II are examples. The current blacklist is case sensitive.
My fix is to perform a case insensitive comparison of the blacklist.