### PR TITLE
Remove storefront name from game titles

### DIFF
--- a/src/consts.py
+++ b/src/consts.py
@@ -68,3 +68,12 @@ COMMA_SPLIT_BLACKLIST = [
     "Upwards, Lonely Robot",
     "Warlock 2: The Exiled - The Good, the Bad, & the Muddy",
 ]
+
+PLATFORM_TITLES_TO_REMOVE = [
+    "(Steam)",
+    "Steam Key",
+    "(Origin)",
+    "Origin Key",
+    "(Uplay)",
+    "(Humble Original)",
+]

--- a/src/library.py
+++ b/src/library.py
@@ -153,10 +153,15 @@ class LibraryResolver:
         """Extract list of KeyGame objects from single Key"""
         logger.info(f'Spliting {key}')
         names = key.human_name.split(', ')
-        return [
-            KeyGame(key, f'{key.machine_name}_{i}', name)
-            for i, name in enumerate(names)
-        ]
+        games = []
+
+        for i, name in enumerate(names):
+            # Multi-game packs have the word "and" in front of the last game name
+            first, _, rest = name.partition(" ")
+            if first == "and": name = rest or first
+            logger.debug(f"Split game: {name}")
+            games.append(KeyGame(key, f'{key.machine_name}_{i}', name))
+        return games
 
     @staticmethod
     def _get_key_infos(orders: list) -> List[KeyInfo]:
@@ -173,7 +178,7 @@ class LibraryResolver:
                 else:
                     keys.append(KeyInfo(key, product_category))
         return keys
-
+    
     def _get_key_games(self, orders: list, show_revealed_keys: bool) -> List[KeyGame]:
         key_games = []
         key_infos = self._get_key_infos(orders)

--- a/src/library.py
+++ b/src/library.py
@@ -142,8 +142,8 @@ class LibraryResolver:
             return False
         if ', ' not in key.human_name:
             return False
-        for i in blacklist:
-            if i in key.human_name:
+        for i in map(str.casefold, blacklist):
+            if i in key.human_name.casefold():
                 logger.debug(f'{key} split blacklisted by "{i}"')
                 return False
         return True

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -203,6 +203,17 @@ def test_split_multigame_key():
         KeyGame(key, "deepsilver_bundle_initial_steam_2", "Sacred Citadel"),
     ]
 
+@pytest.mark.parametrize('human_name, expected', [
+    ('TerraTech Deluxe Edition (Steam)', 'TerraTech Deluxe Edition'),
+    ('Saints Row: The Third Steam Key', 'Saints Row: The Third'),
+    ("Assassin's Creed® Origins (Uplay)", "Assassin's Creed® Origins"),
+    ('Crysis 2 Maximum Edition (Origin)', 'Crysis 2 Maximum Edition'),
+    ('Steamworld Heist', 'Steamworld Heist'),
+    ('Tailwind: Prologue (Humble Original)', 'Tailwind: Prologue'),
+])
+def test_strip_platform_from_name(human_name, expected):
+    assert LibraryResolver._strip_platform_from_name(human_name) == expected
+
 def test_get_key_info():
     key_data_1 = {
         "machine_name": "g1",

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -166,6 +166,7 @@ async def test_fetch_orders_filter_errors_one_404(plugin, create_resolver, caplo
     ('Gremlins, Inc.', 'bundle', ['Here, there', 'Gremlins, I'], False),  # blacklisted
     ('Gremlins, Inc.', 'bundle', ['Here, there', 'Gremlins, no match'], True),
     ('Alpha Protocol, Company of Heroes, Rome: Total War, Hell Yeah! Wrath of the Dead Rabbit', 'bundle', [], True),
+    ('Star Wars™ Battlefront™ II (Classic, 2005)', 'bundle', ['STAR WARS™ Battlefront™ II (Classic, 2005)'], False), # Casing in name changed
 ])
 def test_is_multigame_key(human_name, category, blacklist, is_multigame):
     """Most common case where 1 key == 1 game"""

--- a/tests/common/test_library.py
+++ b/tests/common/test_library.py
@@ -190,6 +190,17 @@ def test_split_multigame_key():
         KeyGame(key, "sega_3", "Hell Yeah! Wrath of the Dead Rabbit")
     ]
 
+    # Many bundle keys add the word 'and' before the last game title
+    tpks = {
+        "machine_name": "deepsilver_bundle_initial_steam",
+        "human_name": "Metro 2033, Risen, and Sacred Citadel",
+    }
+    key = Key(tpks)
+    assert LibraryResolver._split_multigame_key(key) == [
+        KeyGame(key, "deepsilver_bundle_initial_steam_0", "Metro 2033"),
+        KeyGame(key, "deepsilver_bundle_initial_steam_1", "Risen"),
+        KeyGame(key, "deepsilver_bundle_initial_steam_2", "Sacred Citadel"),
+    ]
 
 def test_get_key_info():
     key_data_1 = {


### PR DESCRIPTION
Some games include the name of the storefront the key is for, such as "Steam Key" in their titles.
These shouldn't be part of the titles when imported into Galaxy.

This submission strips those from the title.

Note:
This is based on changes submitted in PR #157. So until that PR is merged, this will probably show the changes from that PR as well.
I separated this out for two reasons: 1) It's not related, and 2) I didn't want to risk the fixes in #157 in case this is rejected for some reason.
The commit specific to this PR is https://github.com/UncleGoogle/galaxy-integration-humblebundle/commit/b7d353cf482f6e0ab0dced7a93a8c56de45ff5c5.

Unfortunately, I can't seem to clear out my Galaxy library, so the old game titles still appear. However, I verified this fix by adding tests, and checking the logs when connecting the plugin.